### PR TITLE
feat(bug-report): add bug report FAB with GitHub issue prefill

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -25,6 +25,7 @@ import PersonIcon from "@mui/icons-material/Person";
 import AddIcon from "@mui/icons-material/Add";
 import LogoutIcon from "@mui/icons-material/Logout";
 import InfoOutlinedIcon from "@mui/icons-material/InfoOutlined";
+import BugReportOutlinedIcon from "@mui/icons-material/BugReportOutlined";
 import RouletteWheel from "@/components/wheel/RouletteWheel";
 import { useFoodOutlets } from "@/hooks/useFoodOutlets";
 import { useUIStore } from "@/lib/store/uiStore";
@@ -37,6 +38,7 @@ import { FoodOutlet } from "@/types/foodOutlet";
 import AddFoodOutletModal from "@/components/food_outlet/AddFoodOutletModal";
 import AuthDialog from "@/components/auth/AuthDialog";
 import AboutModal from "@/components/layout/AboutModal";
+import BugReportModal from "@/components/layout/BugReportModal";
 import WheelListModal from "@/components/wheel/WheelListModal";
 
 
@@ -64,6 +66,7 @@ export default function Home() {
   const [displayNameOpen, setDisplayNameOpen] = useState(false);
   const [displayNameInput, setDisplayNameInput] = useState("");
   const [aboutOpen, setAboutOpen] = useState(false);
+  const [bugReportOpen, setBugReportOpen] = useState(false);
   const [wheelListOpen, setWheelListOpen] = useState(false);
   const [menuAnchor, setMenuAnchor] = useState<null | HTMLElement>(null);
 
@@ -112,6 +115,28 @@ export default function Home() {
         <svg viewBox="0 0 24 24" width="18" height="18" fill="#5865F2" xmlns="http://www.w3.org/2000/svg">
           <path d="M20.317 4.37a19.791 19.791 0 0 0-4.885-1.515.074.074 0 0 0-.079.037c-.21.375-.444.864-.608 1.25a18.27 18.27 0 0 0-5.487 0 12.64 12.64 0 0 0-.617-1.25.077.077 0 0 0-.079-.037A19.736 19.736 0 0 0 3.677 4.37a.07.07 0 0 0-.032.027C.533 9.046-.32 13.58.099 18.057a.082.082 0 0 0 .031.057 19.9 19.9 0 0 0 5.993 3.03.078.078 0 0 0 .084-.028c.462-.63.874-1.295 1.226-1.994a.076.076 0 0 0-.041-.106 13.107 13.107 0 0 1-1.872-.892.077.077 0 0 1-.008-.128 10.2 10.2 0 0 0 .372-.292.074.074 0 0 1 .077-.01c3.928 1.793 8.18 1.793 12.062 0a.074.074 0 0 1 .078.01c.12.098.246.198.373.292a.077.077 0 0 1-.006.127 12.299 12.299 0 0 1-1.873.892.077.077 0 0 0-.041.107c.36.698.772 1.362 1.225 1.993a.076.076 0 0 0 .084.028 19.839 19.839 0 0 0 6.002-3.03.077.077 0 0 0 .032-.054c.5-5.177-.838-9.674-3.549-13.66a.061.061 0 0 0-.031-.03zM8.02 15.33c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.956-2.419 2.157-2.419 1.21 0 2.176 1.096 2.157 2.42 0 1.333-.956 2.418-2.157 2.418zm7.975 0c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.955-2.419 2.157-2.419 1.21 0 2.176 1.096 2.157 2.42 0 1.333-.946 2.418-2.157 2.418z"/>
         </svg>
+      </IconButton>
+
+      {/* Bug report FAB — below Discord, top-left */}
+      <IconButton
+        onClick={() => setBugReportOpen(true)}
+        aria-label="report a bug"
+        sx={{
+          position: "absolute",
+          top: 58,
+          left: 14,
+          zIndex: 30,
+          width: 36,
+          height: 36,
+          bgcolor: "#FFFFFF",
+          border: "1.5px solid rgba(0,0,0,0.08)",
+          boxShadow: "0 4px 12px rgba(0,0,0,0.10)",
+          "&:hover": { bgcolor: "#FFF4F0" },
+          "&:active": { transform: "scale(0.9)" },
+          transition: "all 0.15s ease",
+        }}
+      >
+        <BugReportOutlinedIcon sx={{ fontSize: 18, color: "#6B7280" }} />
       </IconButton>
 
       {/* FAB column: user badge + filter button, stacked top-right */}
@@ -396,6 +421,7 @@ export default function Home() {
       <AddFoodOutletModal open={addModalOpen} onClose={() => setAddModalOpen(false)} />
       <AuthDialog open={authDialogOpen} onClose={() => setAuthDialogOpen(false)} />
       <AboutModal open={aboutOpen} onClose={() => setAboutOpen(false)} />
+      <BugReportModal open={bugReportOpen} onClose={() => setBugReportOpen(false)} />
       <WheelListModal open={wheelListOpen} onClose={() => setWheelListOpen(false)} />
 
       <Dialog open={displayNameOpen} onClose={() => setDisplayNameOpen(false)} maxWidth="xs" fullWidth PaperProps={{ sx: { borderRadius: "16px", mx: 2 } }}>

--- a/components/layout/BugReportModal.tsx
+++ b/components/layout/BugReportModal.tsx
@@ -1,0 +1,106 @@
+"use client";
+
+import { useState } from "react";
+import Dialog from "@mui/material/Dialog";
+import DialogTitle from "@mui/material/DialogTitle";
+import DialogContent from "@mui/material/DialogContent";
+import DialogActions from "@mui/material/DialogActions";
+import Box from "@mui/material/Box";
+import Typography from "@mui/material/Typography";
+import TextField from "@mui/material/TextField";
+import Button from "@mui/material/Button";
+import IconButton from "@mui/material/IconButton";
+import CloseIcon from "@mui/icons-material/Close";
+import OpenInNewIcon from "@mui/icons-material/OpenInNew";
+
+const GITHUB_ISSUES_URL = "https://github.com/hmcldryl/KaEatSaan/issues/new";
+
+interface BugReportModalProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+export default function BugReportModal({ open, onClose }: BugReportModalProps) {
+  const [title, setTitle] = useState("");
+  const [description, setDescription] = useState("");
+
+  const handleClose = () => {
+    setTitle("");
+    setDescription("");
+    onClose();
+  };
+
+  const handleSubmit = () => {
+    const params = new URLSearchParams({ labels: "bug" });
+    if (title.trim()) params.set("title", title.trim());
+    if (description.trim()) params.set("body", description.trim());
+    window.open(`${GITHUB_ISSUES_URL}?${params.toString()}`, "_blank", "noopener,noreferrer");
+    handleClose();
+  };
+
+  return (
+    <Dialog
+      open={open}
+      onClose={handleClose}
+      maxWidth="xs"
+      fullWidth
+      PaperProps={{ sx: { borderRadius: "16px", mx: 2 } }}
+    >
+      <DialogTitle sx={{ pb: 0.5, display: "flex", alignItems: "center", gap: 1 }}>
+        <Box sx={{ flex: 1 }}>
+          <Typography sx={{ fontWeight: 700, fontSize: "1rem", lineHeight: 1 }}>
+            Report a bug
+          </Typography>
+          <Typography sx={{ fontSize: "0.72rem", color: "#9CA3AF", mt: 0.25 }}>
+            Opens a pre-filled GitHub issue in a new tab
+          </Typography>
+        </Box>
+        <IconButton size="small" onClick={handleClose}>
+          <CloseIcon fontSize="small" />
+        </IconButton>
+      </DialogTitle>
+
+      <DialogContent sx={{ pt: 1.5, display: "flex", flexDirection: "column", gap: 2 }}>
+        <TextField
+          autoFocus
+          fullWidth
+          size="small"
+          label="Title"
+          placeholder="e.g. Wheel freezes after spinning twice"
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+          inputProps={{ maxLength: 120 }}
+        />
+        <TextField
+          fullWidth
+          multiline
+          minRows={4}
+          size="small"
+          label="What happened?"
+          placeholder="Steps to reproduce, what you expected, what you got instead..."
+          value={description}
+          onChange={(e) => setDescription(e.target.value)}
+        />
+        <Typography sx={{ fontSize: "0.68rem", color: "#9CA3AF" }}>
+          You&apos;ll need a GitHub account to submit — the form just saves you the typing.
+        </Typography>
+      </DialogContent>
+
+      <DialogActions sx={{ px: 2.5, pb: 2, pt: 0.5 }}>
+        <Button onClick={handleClose} size="small" sx={{ color: "#6B7280" }}>
+          Cancel
+        </Button>
+        <Button
+          variant="contained"
+          size="small"
+          endIcon={<OpenInNewIcon sx={{ fontSize: 14 }} />}
+          onClick={handleSubmit}
+          disabled={!title.trim()}
+          sx={{ bgcolor: "#FF6B35", "&:hover": { bgcolor: "#E55A20" }, borderRadius: "9999px", fontWeight: 700 }}
+        >
+          Continue on GitHub
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}


### PR DESCRIPTION
## Summary
- New FAB below the Discord button opens a Bug Report modal (title + description)
- "Continue on GitHub" opens github.com/hmcldryl/KaEatSaan/issues/new in a new tab, prefilled with title/body and labels=bug
- No auto-filing: static export + Firebase Hosting has no server to hold a GitHub token safely

## Test plan
- [ ] Click bug report FAB, confirm modal opens below Discord button
- [ ] Fill title + description, click "Continue on GitHub", confirm new tab opens with fields prefilled and bug label applied
- [ ] Confirm "Continue on GitHub" disabled when title empty