### PR TITLE
fix: revert CI re-bump to 2.0.0, restore version rollback [skip ci]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,32 +1,3 @@
-# [2.0.0](https://github.com/hmcldryl/KaEatSaan/compare/v1.3.0...v2.0.0) (2026-08-13)
-
-
-### Bug Fixes
-
-* **outlets:** classification chip, live detail data, undefined save fix ([cf47d85](https://github.com/hmcldryl/KaEatSaan/commit/cf47d85b55994a55102af5d6fa08a4b82938cab2))
-* **storage:** correct kaeatsaan typo in persist keys and user-agent ([4ea29cf](https://github.com/hmcldryl/KaEatSaan/commit/4ea29cf91cf670c2adea001ce481eb93ea32b58e))
-
-
-### chore
-
-* **release:** roll back version to 1.4.0, retract v2.0.0 line ([318ca78](https://github.com/hmcldryl/KaEatSaan/commit/318ca78fcd46c678e94b34ee1ea588dea4561e02))
-
-
-### Features
-
-* **bug-report:** add bug report FAB with GitHub issue prefill ([1115f46](https://github.com/hmcldryl/KaEatSaan/commit/1115f46eee6f09fd3b3d3a11e70931fabc0041d5))
-* **ui:** outlet detail page, XP system, merged badge, display name, floating emojis ([120fdd8](https://github.com/hmcldryl/KaEatSaan/commit/120fdd83453decc7df63a7e6b33c58d5a83a58cd))
-* **wheel:** add kainan list, reposition wheel, add loading skeleton ([3a8d642](https://github.com/hmcldryl/KaEatSaan/commit/3a8d64278932cba139f08121e49985154d28af8c))
-
-
-### BREAKING CHANGES
-
-* **release:** footer.
-* **storage:** renamed persist keys (kaetsaan-favorites,
-kaetsaan-history, kaetsaan-location -> kaeatsaan-*) drop existing
-users' saved favorites, history, and location on next load — old
-keys are orphaned, not migrated.
-
 # [1.4.0](https://github.com/hmcldryl/KaEatSaan/compare/v1.3.0...v1.4.0) (2026-08-13)
 
 Supersedes the v2.0.0 / v2.0.0-beta.1 / v2.0.0-beta.2 tags and GitHub

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ka-eat-saan",
-  "version": "2.0.0",
+  "version": "1.4.0",
   "private": true,
   "license": "MIT",
   "scripts": {


### PR DESCRIPTION
## What happened
Merging #56 pushed to `main`, which triggered `deploy.yml` before the `v1.4.0` tag existed. `semantic-release` recomputed from the only remaining tag (`v1.3.0`), saw the original `storage` `BREAKING CHANGE` commit still un-tagged, and bumped to `2.0.0` again — silently undoing the rollback.

## Fix
Revert the auto-commit (`58e8aba7`), restoring `package.json`/`CHANGELOG.md` to the correct `1.4.0` state. Deleted the re-created `v2.0.0` tag/release again.

Commit message carries `[skip ci]` so **this merge does not trigger another release run** — right after it lands I'm pushing the `v1.4.0` tag manually and cutting the GH Release from it. That tag is what actually closes the loop: once it exists, semantic-release only looks at commits *after* it, so the old breaking-change commit can never trigger a bump again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)