### PR TITLE
chore: add CODEOWNERS, gate main on code-owner review

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Every file needs the code owner's approval before merging into main.
+* @hmcldryl


### PR DESCRIPTION
## Summary
Adds `.github/CODEOWNERS` (`* @hmcldryl`) and pairs it with a branch-protection update on `main` (`require_code_owner_reviews: true`) — any PR touching any file needs @hmcldryl's explicit approval before merge.

`enforce_admins` stays `false` deliberately: GitHub blocks approving your own PR, so if admin bypass were also off, @hmcldryl's own PRs (as sole collaborator) could never be merged — no override exists. Keeping it off preserves a self-merge path for solo work while still fully gating anyone else who's added later.

No app code touched — `[skip ci]`.

## After merge
I'll update the branch protection API settings (`require_code_owner_reviews: true`) to match — that part isn't a file change so isn't in this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)