### PR TITLE
ci: add pull_request lint+build check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,41 @@
+name: CI
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build:
+    name: Lint & Build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Build
+        run: npm run build
+        env:
+          # Real values live in the `production` environment (gated by a
+          # reviewer-approval protection rule) and aren't appropriate here —
+          # this build only needs to prove `next build` succeeds, its output
+          # is never deployed. Placeholders are enough for that.
+          NEXT_PUBLIC_FIREBASE_API_KEY: "ci-placeholder"
+          NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN: "ci-placeholder.firebaseapp.com"
+          NEXT_PUBLIC_FIREBASE_DATABASE_URL: "https://ci-placeholder-default-rtdb.firebasedatabase.app"
+          NEXT_PUBLIC_FIREBASE_PROJECT_ID: "ci-placeholder"
+          NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET: "ci-placeholder.firebasestorage.app"
+          NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID: "000000000000"
+          NEXT_PUBLIC_FIREBASE_APP_ID: "1:000000000000:web:0000000000000000000000"


### PR DESCRIPTION
## Summary
Adds a `pull_request`-triggered workflow (`.github/workflows/ci.yml`) running `npm run lint` and `npm run build` on every PR into `main`. Today nothing checks a PR before merge — `deploy.yml` only runs on push to `main`, so a broken build was only caught post-merge, during deploy.

Build uses placeholder `NEXT_PUBLIC_FIREBASE_*` values — the real ones live in the `production` GitHub environment behind a reviewer-approval gate, which is the wrong fit for a PR check that should run unattended. This build's only job is proving `next build` succeeds; its output is never deployed.

Verified locally with the same placeholder values — `npm run lint` and `npm run build` both pass.

## After merge
Add `Lint & Build` as a required status check in branch protection, plus turn on "require branches up to date" and "require conversation resolution" — this PR is the prerequisite (needs to run once so GitHub has the check name to reference).

🤖 Generated with [Claude Code](https://claude.com/claude-code)