### PR TITLE
docs: remove stale dev-environment references

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,10 +9,10 @@ First off, thanks for being interested in helping out! I'm not super strict abou
 1. **Fork the repository** - Click the "Fork" button on GitHub to create your own copy
 2. **Clone your fork** - `git clone https://github.com/YOUR_USERNAME/KaEatSaan.git`
 3. **Add upstream remote** - `git remote add upstream https://github.com/hmcldryl/KaEatSaan.git`
-4. **Create a branch** - `git checkout -b feature/your-feature-name`
+4. **Create a branch** - `git checkout -b feat/your-feature-name`
 5. **Make your changes and commit**
-6. **Push to your fork** - `git push origin feature/your-feature-name`
-7. **Open a Pull Request** - From your fork to the `develop` branch of the main repo
+6. **Push to your fork** - `git push origin feat/your-feature-name`
+7. **Open a Pull Request** - From your fork to the `main` branch of the main repo
 
 ### For Collaborators (Direct Access)
 
@@ -21,12 +21,12 @@ If you have collaborator access, you can create branches directly on the repo.
 ## The Super Simple Workflow
 
 1.  **Branching:** Create a new branch for your feature or fix. I like to name them like this:
-    - `feature/sample-feature`
+    - `feat/sample-feature`
     - `fix/bug-fix-name`
 
 2.  **Commits:** I try to stick to [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/). It helps keep the history clean. A simple `feat: add new button` or `fix: correct a typo` is perfect.
 
-3.  **Pull Requests (PRs):** When you're ready, open a Pull Request from your branch to the `develop` branch.
+3.  **Pull Requests (PRs):** When you're ready, open a Pull Request from your branch to the `main` branch.
 
 ## PRs, Templates, and Labels
 Honestly, I'm still too lazy to enforce strict templates and a bunch of labels. But there are some simple PR templates to help keep things a little organized. They're not required - just a guide to make PRs cleaner. Give your PR a clear title, fill in the template if you want, and that's good enough for me.

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ KaEatSaan (a play on "Kahit Saan" or "Anywhere") is your trusty sidekick for tho
 
 1. Clone the repo
 2. Install dependencies: `npm install`
-3. Copy `.env.development` and fill in your Firebase config (`NEXT_PUBLIC_FIREBASE_*` vars)
+3. Copy `.env.local` and fill in your Firebase config (`NEXT_PUBLIC_FIREBASE_*` vars)
 4. Run the dev server: `npm run dev`
 
 Other commands:
@@ -58,14 +58,11 @@ npm run build   # Production build (static export to /out)
 npm run lint    # ESLint v9
 ```
 
-## Environments 🌐
+## Deployment 🌐
 
-We have two environments fully set up:
+Single production environment, deployed from `main`:
 
-- **Production:** [kaeatsaan.web.app](https://kaeatsaan.web.app)
-- **Development:** [dev-kaeatsaan.web.app](https://dev-kaeatsaan.web.app)
-
-Each environment has its own hosting and database configuration.
+- **Production:** [kaeatsaan.web.app](https://kaeatsaan.web.app) (custom domain: [kaeatsaan.com](https://kaeatsaan.com))
 
 ## Testing 🧪
 


### PR DESCRIPTION
## Summary
README and CONTRIBUTING still referenced the retired dev Firebase project and `develop` branch.

## Changes
- **README**: `.env.development` → `.env.local`; dropped the two-environment section, replaced with a single Deployment section noting the `kaeatsaan.com` custom domain
- **CONTRIBUTING**: PR target `develop` → `main`; `feature/` → `feat/` branch prefix to match `CLAUDE.md`'s convention

Docs only, `[skip ci]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)