### PR TITLE
docs: drop .web.app mentions, use kaeatsaan.com only

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,4 +72,4 @@ Public Firebase config vars prefixed `NEXT_PUBLIC_FIREBASE_*`, stored in `.env.p
 
 ## Deployment
 
-GitHub Actions (`.github/workflows/deploy.yml`) deploys `main` to production (`kaeatsaan.web.app`, custom domain `kaeatsaan.com`). Runs semantic-release, build, deploy to Firebase Hosting, sends Discord notification. Canonical `<link>` tag + a `beforeInteractive` redirect script in `app/layout.tsx` bounce visitors from `*.web.app`/`*.firebaseapp.com` to `kaeatsaan.com`.
+GitHub Actions (`.github/workflows/deploy.yml`) deploys `main` to production (`kaeatsaan.com`). Runs semantic-release, build, deploy to Firebase Hosting, sends Discord notification. Canonical `<link>` tag + a `beforeInteractive` redirect script in `app/layout.tsx` bounce visitors from Firebase's default hosting domains to `kaeatsaan.com`.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 [![Updated Badge](https://badges.pufler.dev/updated/hmcldryl/kaeatsaan)](https://github.com/hmcldryl/KaEatSaan/)
 [![Visits Badge](https://badges.pufler.dev/visits/hmcldryl/kaeatsaan)](https://github.com/hmcldryl/KaEatSaan/)
 [![License: MIT License](https://img.shields.io/badge/License-MIT-brightgreen.svg)](https://opensource.org/licenses/MIT)
-[![Website](https://img.shields.io/website-up-down-green-red/http/shields.io.svg)](http://kaeatsaan.web.app/)
+[![Website](https://img.shields.io/website-up-down-green-red/http/shields.io.svg)](https://kaeatsaan.com/)
   
 ![Next JS](https://img.shields.io/badge/Next-black.svg?style=for-the-badge&logo=next.js&logoColor=white)
 ![Firebase](https://img.shields.io/badge/firebase-%23039BE5.svg?style=for-the-badge&logo=firebase)
@@ -57,12 +57,6 @@ Other commands:
 npm run build   # Production build (static export to /out)
 npm run lint    # ESLint v9
 ```
-
-## Deployment 🌐
-
-Single production environment, deployed from `main`:
-
-- **Production:** [kaeatsaan.web.app](https://kaeatsaan.web.app) (custom domain: [kaeatsaan.com](https://kaeatsaan.com))
 
 ## Testing 🧪
 


### PR DESCRIPTION
## Summary
Follow-up to #60 — that PR got merged before this second commit was pushed to the branch, so it never landed on `main`. Opening fresh.

## Changes
- README: removed the Deployment section entirely (was still naming `kaeatsaan.web.app`), fixed the website badge link (was `http://kaeatsaan.web.app/`)
- CLAUDE.md: deployment doc no longer names `kaeatsaan.web.app`

`.web.app`/`.firebaseapp.com` still referenced functionally in `deploy.yml`'s health-check fallback and `layout.tsx`'s redirect script — those are correct to keep, not documentation.

`[skip ci]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)